### PR TITLE
Add viewCount property to news API - show total views per news

### DIFF
--- a/portfolio-server/src/services/newsViewsService.js
+++ b/portfolio-server/src/services/newsViewsService.js
@@ -148,11 +148,18 @@ class NewsViewsService {
             const viewedNewsIds = new Set(viewedNews.map(view => view.news_id))
 
             // Add isViewed property to each news
-            const newsWithStatus = news.map(newsItem => {
-                const newsData = newsItem.toJSON()
-                newsData.isViewed = viewedNewsIds.has(newsData.id)
-                return newsData
+            // Add isViewed and viewCount properties to each news
+            const newsWithStatus = await Promise.all(news.map(async (newsItem) => {
+            const newsData = newsItem.toJSON()
+            newsData.isViewed = viewedNewsIds.has(newsData.id)
+
+            // Add view count for this news
+            newsData.viewCount = await NewsViews.count({
+                where: { news_id: newsData.id }
             })
+
+            return newsData
+}))
 
             console.log('News with status:', newsWithStatus.length)
 


### PR DESCRIPTION
- Add viewCount to each news item in with-status endpoint
- Show total number of users who viewed each news
- Enhance getNewsWithViewStatus method in newsViewsService
- Update Promise.all with async map for proper await handling
- Improve user experience with view statistics display

API Response now includes:
- viewCount: total users who viewed the news
- isViewed: current user's view status
- Enhanced news analytics for better insights

Endpoint: GET /api/news-views/with-status
Status: Ready for production"