### PR TITLE
fix: honor recruiter visibility flag in news lookup

### DIFF
--- a/portfolio-server/src/services/newsService.js
+++ b/portfolio-server/src/services/newsService.js
@@ -262,7 +262,10 @@ class NewsService {
 			// no extra restrictions
 		} else if (user.userType === 'Recruiter') {
 			finalConditions.push({
-				[Op.or]: [{ status: 'approved' }, { authorId: user.id, authorType: 'Recruiter' }],
+				[Op.or]: [
+					{ status: 'approved', visible_to_recruiter: true },
+					{ authorId: user.id, authorType: 'Recruiter' },
+				],
 			})
 		} else {
 			finalConditions.push({ status: 'approved' })


### PR DESCRIPTION
## Summary
- ensure recruiter getById requests respect the visible_to_recruiter flag unless they authored the news item

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f4f5bdf90c832faf3a1fbb0d4d8e4c