### PR TITLE
fix: gate student markdown export behind opt-in

### DIFF
--- a/portfolio-client/src/pages/Profile/StudentProfile/ProfileMarkdownBlock.jsx
+++ b/portfolio-client/src/pages/Profile/StudentProfile/ProfileMarkdownBlock.jsx
@@ -1,0 +1,90 @@
+import CheckIcon from '@mui/icons-material/Check'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import PropTypes from 'prop-types'
+import { useMemo, useState } from 'react'
+import generateStudentProfileMarkdown from '../../../utils/generateStudentProfileMarkdown'
+import styles from './StudentProfile.module.css'
+
+const copyToClipboard = async text => {
+	if (!text) return false
+
+	if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text)
+			return true
+		} catch (_error) {
+			// Fallback to legacy copy method
+		}
+	}
+
+	if (typeof document === 'undefined') {
+		return false
+	}
+
+	const textArea = document.createElement('textarea')
+	textArea.value = text
+	textArea.setAttribute('readonly', '')
+	textArea.style.position = 'absolute'
+	textArea.style.left = '-9999px'
+	document.body.appendChild(textArea)
+	const selection = document.getSelection()
+	const selectedRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
+
+	textArea.select()
+	let copied = false
+	try {
+		copied = document.execCommand('copy')
+	} catch (_error) {
+		copied = false
+	} finally {
+		document.body.removeChild(textArea)
+		if (selectedRange && selection) {
+			selection.removeAllRanges()
+			selection.addRange(selectedRange)
+		}
+	}
+
+	return copied
+}
+
+const ProfileMarkdownBlock = ({ student }) => {
+	const markdown = useMemo(() => generateStudentProfileMarkdown(student), [student])
+	const [copied, setCopied] = useState(false)
+
+	if (!markdown) {
+		return null
+	}
+
+	const handleCopy = async () => {
+		const success = await copyToClipboard(markdown)
+		if (success) {
+			setCopied(true)
+			setTimeout(() => setCopied(false), 2000)
+		}
+	}
+
+	return (
+		<Box className={styles.markdownContainer}>
+			<Box className={styles.markdownHeader}>
+				<Typography component='span' className={styles.markdownTitle}>
+					Markdown profile snapshot
+				</Typography>
+				<Tooltip title={copied ? 'Copied!' : 'Copy Markdown'} placement='left'>
+					<IconButton aria-label='Copy profile as Markdown' onClick={handleCopy} size='small'>
+						{copied ? <CheckIcon fontSize='small' /> : <ContentCopyIcon fontSize='small' />}
+					</IconButton>
+				</Tooltip>
+			</Box>
+			<pre className={styles.markdownBody}>
+				<code>{markdown}</code>
+			</pre>
+		</Box>
+	)
+}
+
+ProfileMarkdownBlock.propTypes = {
+	student: PropTypes.shape({}),
+}
+
+export default ProfileMarkdownBlock

--- a/portfolio-client/src/pages/Profile/StudentProfile/StudentProfile.jsx
+++ b/portfolio-client/src/pages/Profile/StudentProfile/StudentProfile.jsx
@@ -1,13 +1,14 @@
 import EmailIcon from '@mui/icons-material/Email'
 import { Avatar, Box, IconButton } from '@mui/material'
 import PropTypes from 'prop-types'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
 import ArrowGoBackIcon from '../../../assets/icons/arrow-go-back-line.svg'
 import { UserContext } from '../../../contexts/UserContext'
 import translations from '../../../locales/translations'
 import axios from '../../../utils/axiosUtils'
 import styles from './StudentProfile.module.css'
+import ProfileMarkdownBlock from './ProfileMarkdownBlock'
 
 const StudentProfile = ({ userId = 0 }) => {
 	const { studentId } = useParams()
@@ -50,6 +51,28 @@ const StudentProfile = ({ userId = 0 }) => {
 	const [student, setStudent] = useState(null)
 	const [loading, setLoading] = useState(true)
 	const [error, setError] = useState(null)
+
+	const shouldShowAiMarkdown = useMemo(() => {
+		if (role !== 'Student') {
+			return false
+		}
+
+		const searchParams = new URLSearchParams(location.search)
+		const queryValue = searchParams.get('aiMarkdown')
+		const normalizedQuery = queryValue ? queryValue.toLowerCase() : null
+		const enabledByQuery = normalizedQuery === '1' || normalizedQuery === 'true' || normalizedQuery === 'yes'
+		const enabledByHash = location.hash?.toLowerCase().includes('aimarkdown')
+
+		return enabledByQuery || enabledByHash
+	}, [location.hash, location.search, role])
+
+	const markdownRevealUrl = useMemo(() => {
+		const params = new URLSearchParams(location.search)
+		params.set('aiMarkdown', '1')
+		const searchString = params.toString()
+
+		return `${location.pathname}?${searchString}${location.hash || ''}`
+	}, [location.hash, location.pathname, location.search])
 
 	useEffect(() => {
 		// Wait for context initialization before attempting to fetch
@@ -274,6 +297,14 @@ const StudentProfile = ({ userId = 0 }) => {
 					</Box>
 				</Box>
 			</Box>
+			{role === 'Student' && !shouldShowAiMarkdown && (
+				<Box className={styles.markdownHint}>
+					<span>Need an AI-friendly export? </span>
+					<a href={markdownRevealUrl}>Open the Markdown view</a>
+					<span> to reveal the copy block.</span>
+				</Box>
+			)}
+			{shouldShowAiMarkdown && <ProfileMarkdownBlock student={student} />}
 			<Outlet />
 		</Box>
 	)

--- a/portfolio-client/src/pages/Profile/StudentProfile/StudentProfile.module.css
+++ b/portfolio-client/src/pages/Profile/StudentProfile/StudentProfile.module.css
@@ -71,6 +71,60 @@
 	align-items: end;
 }
 
+.markdownContainer {
+	margin: 24px 16px 0;
+	border: 1px solid #e2e8f0;
+	border-radius: 12px;
+	background: linear-gradient(180deg, #f8fafc 0%, #ffffff 100%);
+	box-shadow: 0 10px 30px -12px rgba(15, 23, 42, 0.25);
+	overflow: hidden;
+}
+
+.markdownHint {
+	margin: 24px 16px 0;
+	font-size: 13px;
+	line-height: 1.6;
+	color: #475569;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+
+.markdownHint a {
+	color: #5627db;
+	text-decoration: underline;
+	font-weight: 600;
+}
+
+.markdownHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 16px;
+	background: rgba(86, 39, 219, 0.06);
+	border-bottom: 1px solid #e2e8f0;
+}
+
+.markdownTitle {
+	font-size: 14px;
+	font-weight: 600;
+	color: #1e293b;
+	letter-spacing: 0.01em;
+	text-transform: uppercase;
+}
+
+.markdownBody {
+	margin: 0;
+	padding: 16px;
+	font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+	font-size: 14px;
+	line-height: 1.6;
+	color: #0f172a;
+	background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+	white-space: pre-wrap;
+	overflow-x: auto;
+}
+
 /* University group desktop + mobile variants */
 .desktopUniversityGroup {
 	display: block;
@@ -198,5 +252,11 @@
 	}
 	.desktopOnly {
 		display: none;
+	}
+	.markdownContainer {
+		margin: 24px 0 0;
+	}
+	.markdownBody {
+		font-size: 13px;
 	}
 }

--- a/portfolio-client/src/utils/generateStudentProfileMarkdown.js
+++ b/portfolio-client/src/utils/generateStudentProfileMarkdown.js
@@ -1,0 +1,260 @@
+const normalizeArray = value => {
+	if (Array.isArray(value)) {
+		return value.map(item => (typeof item === 'string' ? item.trim() : item)).filter(Boolean)
+	}
+
+	if (typeof value === 'string') {
+		return value
+			.split(/[\n,\u3001]+/)
+			.map(item => item.trim())
+			.filter(Boolean)
+	}
+
+	return []
+}
+
+const parseJSONSafe = value => {
+	if (typeof value !== 'string') {
+		return Array.isArray(value) ? value : []
+	}
+
+	try {
+		const parsed = JSON.parse(value)
+		return Array.isArray(parsed) ? parsed : []
+	} catch (_error) {
+		return []
+	}
+}
+
+const formatMultilineText = value => {
+	if (!value || typeof value !== 'string') return ''
+	return value.replace(/\r\n/g, '\n').trim()
+}
+
+const formatSkillGroups = value => {
+	const groups =
+		typeof value === 'string'
+			? (() => {
+					try {
+						const parsed = JSON.parse(value)
+						return parsed && typeof parsed === 'object' ? parsed : {}
+					} catch (_error) {
+						return {}
+					}
+				})()
+			: value
+
+	if (!groups || typeof groups !== 'object') return []
+
+	return Object.entries(groups)
+		.map(([level, items]) => {
+			const normalized = normalizeArray(items?.map ? items.map(item => item?.name || item) : items)
+			if (normalized.length === 0) return null
+			return `**${level}**: ${normalized.join(', ')}`
+		})
+		.filter(Boolean)
+}
+
+const calculateAge = birthDateString => {
+	if (!birthDateString) return null
+	const today = new Date()
+	const birthDate = new Date(birthDateString)
+	if (Number.isNaN(birthDate.getTime())) return null
+
+	let age = today.getFullYear() - birthDate.getFullYear()
+	const monthDifference = today.getMonth() - birthDate.getMonth()
+	if (monthDifference < 0 || (monthDifference === 0 && today.getDate() < birthDate.getDate())) {
+		age--
+	}
+
+	return age
+}
+
+const addSection = (lines, title, content) => {
+	if (!content) return
+	const normalized = Array.isArray(content) ? content.filter(Boolean) : [content].filter(Boolean)
+	if (normalized.length === 0) return
+	lines.push('', `## ${title}`, '')
+	normalized.forEach(entry => lines.push(entry))
+}
+
+const addKeyValueList = (lines, title, entries) => {
+	const normalized = entries.filter(([, value]) => {
+		if (Array.isArray(value)) return value.length > 0
+		return Boolean(value)
+	})
+
+	if (normalized.length === 0) return
+
+	lines.push('', `## ${title}`, '')
+	normalized.forEach(([label, value]) => {
+		if (Array.isArray(value)) {
+			lines.push(`- **${label}:** ${value.join(', ')}`)
+		} else {
+			lines.push(`- **${label}:** ${value}`)
+		}
+	})
+}
+
+const addDeliverables = (lines, deliverables) => {
+	if (!Array.isArray(deliverables) || deliverables.length === 0) return
+
+	lines.push('', '## Projects & Deliverables', '')
+	deliverables.forEach((deliverable, index) => {
+		const title = deliverable?.title || `Deliverable ${index + 1}`
+		lines.push(`### ${title}`)
+
+		const description = formatMultilineText(deliverable?.description)
+		if (description) {
+			lines.push(description)
+		}
+
+		const detailLines = []
+		const roles = normalizeArray(deliverable?.role)
+		if (roles.length > 0) {
+			detailLines.push(`**Role:** ${roles.join(', ')}`)
+		} else if (typeof deliverable?.role === 'string' && deliverable.role.trim()) {
+			detailLines.push(`**Role:** ${deliverable.role.trim()}`)
+		}
+
+		if (deliverable?.link) {
+			detailLines.push(`[Live Demo](${deliverable.link})`)
+		}
+
+		if (deliverable?.codeLink) {
+			detailLines.push(`[Source Code](${deliverable.codeLink})`)
+		}
+
+		if (detailLines.length > 0) {
+			detailLines.forEach(line => {
+				lines.push(`- ${line}`)
+			})
+		}
+
+		lines.push('')
+	})
+}
+
+const addQASection = (lines, qa) => {
+	if (!Array.isArray(qa) || qa.length === 0) return
+
+	const normalized = qa
+		.map(entry => {
+			if (!entry || typeof entry !== 'object') return null
+			const question = entry.question || entry.question_text || entry.title
+			const answer = formatMultilineText(entry.answer || entry.response)
+			if (!question || !answer) return null
+			return { question, answer }
+		})
+		.filter(Boolean)
+
+	if (normalized.length === 0) return
+
+	lines.push('', '## Q&A Highlights', '')
+	normalized.forEach(item => {
+		lines.push(`**Q:** ${item.question}`)
+		lines.push(`**A:** ${item.answer}`)
+		lines.push('')
+	})
+}
+
+const generateStudentProfileMarkdown = student => {
+	if (!student || typeof student !== 'object') return ''
+
+	const lines = []
+	const draft = student.draft || {}
+	const fullName = [student.first_name, student.last_name].filter(Boolean).join(' ').trim()
+	if (fullName) {
+		lines.push(`# ${fullName}`)
+	} else {
+		lines.push('# Student Profile')
+	}
+
+	const phonetic = [student.last_name_furigana, student.first_name_furigana]
+		.map(part => (typeof part === 'string' ? part.trim() : ''))
+		.filter(Boolean)
+		.join(' ')
+	if (phonetic) {
+		lines.push(`_(${phonetic})_`)
+	}
+
+	const quickFacts = []
+	if (student.student_id) quickFacts.push(['Student ID', student.student_id])
+	const age = calculateAge(student.date_of_birth)
+	if (typeof age === 'number') quickFacts.push(['Age', `${age}`])
+	if (student.expected_graduation_year) quickFacts.push(['Expected Graduation', student.expected_graduation_year])
+	if (student.partner_university) {
+		const parts = [student.partner_university, student.faculty, student.department].filter(Boolean)
+		quickFacts.push(['Partner University', parts.join(' ') || student.partner_university])
+	}
+	if (student.major) quickFacts.push(['Major', student.major])
+	if (student.job_type) quickFacts.push(['Desired Role', student.job_type])
+	if (student.email) quickFacts.push(['Email', student.email])
+
+	addKeyValueList(lines, 'Quick Facts', quickFacts)
+
+	addSection(lines, 'Self Introduction', formatMultilineText(draft.self_introduction || student.self_introduction))
+
+	const hobbiesDescription = formatMultilineText(draft.hobbies_description)
+	const hobbiesList = normalizeArray(draft.hobbies)
+	if (hobbiesDescription || hobbiesList.length) {
+		addSection(lines, 'Hobbies & Interests', hobbiesDescription)
+		if (hobbiesList.length) {
+			lines.push('', '### Favorite Activities', '')
+			hobbiesList.forEach(item => lines.push(`- ${item}`))
+		}
+	}
+
+	const specialDescription = formatMultilineText(draft.special_skills_description)
+	const specialList = normalizeArray(draft.other_information)
+	if (specialDescription || specialList.length) {
+		addSection(lines, 'Special Skills', specialDescription)
+		if (specialList.length) {
+			lines.push('', '### Skill Highlights', '')
+			specialList.forEach(item => lines.push(`- ${item}`))
+		}
+	}
+
+	addKeyValueList(lines, 'Career Preferences', [
+		['Current Location', draft.address || student.address],
+		['Preferred Industries', normalizeArray(draft.preferred_industry || draft.preferred_industries)],
+		['Preferred Locations', normalizeArray(draft.preferred_location || draft.preferred_locations)],
+		['Preferred Job Types', normalizeArray(draft.preferred_jobtype || draft.preferred_jobtypes || draft.job_type)],
+		['Internships', formatMultilineText(draft.internship)],
+	])
+
+	const techSkills = formatSkillGroups(draft.it_skills)
+	const languageSkills = parseJSONSafe(draft.language_skills)
+		.map(skill => {
+			if (!skill || typeof skill !== 'object') return null
+			if (skill.level) {
+				return `${skill.name}: ${skill.level}`
+			}
+			return skill.name || null
+		})
+		.filter(Boolean)
+
+	if (techSkills.length || languageSkills.length) {
+		lines.push('', '## Skills', '')
+		if (techSkills.length) {
+			lines.push('### Technical Skills', '')
+			techSkills.forEach(item => lines.push(`- ${item}`))
+			lines.push('')
+		}
+		if (languageSkills.length) {
+			lines.push('### Languages', '')
+			languageSkills.forEach(item => lines.push(`- ${item}`))
+			lines.push('')
+		}
+	}
+
+	addDeliverables(lines, draft.deliverables)
+	addQASection(lines, draft.qa)
+
+	return lines
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
+export default generateStudentProfileMarkdown


### PR DESCRIPTION
## Summary
- add a Markdown generator that formats student profile data for easy sharing
- render a shadcn-style copy-to-clipboard block on the student profile header
- style the markdown block with responsive spacing so it stays readable on mobile
- hide the markdown export behind a student-only opt-in link and query flag so it is not exposed globally

## Testing
- npm run lint *(fails: existing lint errors in unrelated files — see log)*

------
https://chatgpt.com/codex/tasks/task_b_6901d7b11638832fb92426f313dea3b0