### PR TITLE
style(QAAccordion): adjust qPart display and dimensions for consistency

### DIFF
--- a/portfolio-client/src/components/QAAccordion/QAAccordion.module.css
+++ b/portfolio-client/src/components/QAAccordion/QAAccordion.module.css
@@ -24,9 +24,18 @@
 	border-radius: 100%;
 	padding: 5px;
 	background-color: #d3e0fb;
-	display: flex;
+	display: inline-flex;
 	justify-content: center;
 	align-items: center;
+	/* Prevent vertical stretching when question wraps */
+	width: 36px;
+	height: 36px;
+	flex: 0 0 36px;
+	align-self: flex-start;
+}
+
+.qPart svg {
+	font-size: 20px;
 }
 
 /* ------------------- Responsive (≤ 640px) ------------------- */
@@ -34,6 +43,17 @@
 	.answer {
 		padding-left: 40px !important;
 		max-height: 40vh;
+	}
+
+	.qPart {
+		width: 28px;
+		height: 28px;
+		flex: 0 0 28px;
+		padding: 4px;
+	}
+
+	.qPart svg {
+		font-size: 18px;
 	}
 }
 


### PR DESCRIPTION
- Change display property of .qPart to inline-flex for better alignment
- Update dimensions of .qPart for improved responsiveness on small screens
- Ensure consistent padding and font size for SVG icons within .qPart

These changes enhance the visual consistency and responsiveness of the QAAccordion component.

## Summary

Describe the purpose of this PR in one or two sentences.

## Changes

- What changed at a high level
- Any migrations, API changes, or config updates

## Verification

- Steps to manually verify the change
- Screenshots/GIFs for UI changes
- Sample API requests for backend changes

## Notes

- Formatting normalized to LF via `.gitattributes`.
  - If you see end-of-line–only diffs locally, run `git add --renormalize .` once.
  - Ensure your editor respects LF endings and uses the workspace Prettier.
- Prettier is pinned and used via `npm run format` / `format:check` in each package.
