### PR TITLE
feat: make QA accordion question text selectable and copiable

### DIFF
--- a/portfolio-client/src/components/QAAccordion/QAAccordion.jsx
+++ b/portfolio-client/src/components/QAAccordion/QAAccordion.jsx
@@ -68,7 +68,7 @@ const QAAccordion = ({
 					<div className={styles.qPart}>
 						<HelpOutlineIcon sx={{ color: '#2563eb' }} />
 					</div>
-					<Typography sx={{ pl: '10px', fontSize: 18 }}>{question}</Typography>
+					<Typography sx={{ pl: '10px', fontSize: 18, userSelect: 'text', cursor: 'text' }}>{question}</Typography>
 				</StyledAccordionSummary>
 				{!notExpand && (
 					<AccordionDetails className={styles.answer}>


### PR DESCRIPTION
Added userSelect and cursor CSS properties to the question Typography component to allow users to select and copy the question text without triggering accordion expansion.