### PR TITLE
fix(Table): update default rows per page and pagination options

### DIFF
--- a/portfolio-client/src/components/Table/Table.jsx
+++ b/portfolio-client/src/components/Table/Table.jsx
@@ -24,9 +24,9 @@ import { getComparator, stableSort } from './TableUtils'
 const getInitialRowsPerPage = () => {
 	try {
 		const saved = localStorage.getItem('tableRowsPerPage')
-		return saved ? parseInt(saved, 10) : 10
+		return saved ? parseInt(saved, 10) : 50
 	} catch (error) {
-		return 10
+		return 50
 	}
 }
 
@@ -46,12 +46,12 @@ const EnhancedTable = ({ tableProps, updatedBookmark, viewMode = 'table' }) => {
 	const [orderBy, setOrderBy] = useState(searchParams.get('orderBy') || '')
 	const [sortBy, setSortBy] = useState(searchParams.get('sortBy') || '')
 	const [sortOrder, setSortOrder] = useState(searchParams.get('sortOrder') || '')
-	const [selected, setSelected] = useState([])
+	const [selected, _setSelected] = useState([])
 	const [page, setPage] = useState(parseInt(searchParams.get('page') || '0', 10))
 	const [rowsPerPage, setRowsPerPage] = useAtom(rowsPerPageAtom)
 	const [rows, setRows] = useState([])
 	const [loading, setLoading] = useState(false)
-	const [refresher, setRefresher] = useState(0)
+	const [_refresher, setRefresher] = useState(0)
 	const [anchorEls, setAnchorEls] = useState({})
 	const [deleteModal, setDeleteModal] = useState({
 		open: false,
@@ -379,7 +379,7 @@ const EnhancedTable = ({ tableProps, updatedBookmark, viewMode = 'table' }) => {
 	// Reusable pagination component
 	const PaginationControls = () => (
 		<TablePagination
-			rowsPerPageOptions={[5, 10, 25, 50, 100]}
+			rowsPerPageOptions={[5, 10, 25, 50, 150]}
 			component='div'
 			count={rows.length}
 			rowsPerPage={rowsPerPage}
@@ -850,7 +850,6 @@ const EnhancedTable = ({ tableProps, updatedBookmark, viewMode = 'table' }) => {
 																					)
 																					return revertedRows
 																				})
-																			} else {
 																			}
 																		} catch (error) {
 																			// Revert to previous state on error
@@ -943,7 +942,6 @@ const EnhancedTable = ({ tableProps, updatedBookmark, viewMode = 'table' }) => {
 																					)
 																					return revertedRows
 																				})
-																			} else {
 																			}
 																		} catch (error) {
 																			// Revert to previous state on error


### PR DESCRIPTION
- Change default rows per page from 10 to 50 for better visibility
- Update pagination options to include 150 rows per page
- Ensure consistent state initialization for selected rows

This improves user experience by allowing more data to be viewed at once, reducing the need for frequent pagination.

## Summary

Describe the purpose of this PR in one or two sentences.

## Changes

- What changed at a high level
- Any migrations, API changes, or config updates

## Verification

- Steps to manually verify the change
- Screenshots/GIFs for UI changes
- Sample API requests for backend changes

## Notes

- Formatting normalized to LF via `.gitattributes`.
  - If you see end-of-line–only diffs locally, run `git add --renormalize .` once.
  - Ensure your editor respects LF endings and uses the workspace Prettier.
- Prettier is pinned and used via `npm run format` / `format:check` in each package.
